### PR TITLE
Branch-A-Streams

### DIFF
--- a/src/main/java/mintty/storage/Storage.java
+++ b/src/main/java/mintty/storage/Storage.java
@@ -9,6 +9,9 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**
@@ -31,37 +34,41 @@ public class Storage {
      * @throws Exception if there are some corrupted lines in the file
      */
     public List<Task> load() {
-        // load files from the disk
+        assert filePath != null : "filePath should have been initialized";
+        assert formatter != null : "formatter should have been initialized";
+
         try {
-            // running the 1st time, the list is empty
             if (Files.notExists(filePath)) {
                 return new ArrayList<>();
             }
 
-            List<String> lines = Files.readAllLines(filePath, StandardCharsets.UTF_8);
-            List<Task> tasks = new ArrayList<>();
-
-            for (String line : lines) {
-                String trimmed = line.trim();
-                if (trimmed.isEmpty()) {
-                    continue;
-                }
-
-                try {
-                    Task t = formatter.decode(trimmed);
-                    tasks.add(t);
-                } catch (Exception corruptedLine) {
-                    // stretch: corrupted line handling
-                    System.out.println(separator);
-                    System.out.println("! Warning: " + corruptedLine.getMessage());
-                    System.out.println(separator);
-                }
+            try (Stream<String> lines = Files.lines(filePath, StandardCharsets.UTF_8)) {
+                return lines
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .map(this::decodeOrWarn)          // Optional<Task>
+                        .flatMap(Optional::stream)        // Optional -> Task stream
+                        .collect(Collectors.toList());
             }
-            return tasks;
+
         } catch (IOException e) {
-            // if it failed to read files
-            // return an empty arrayList
             return new ArrayList<>();
+        }
+    }
+
+    private Optional<Task> decodeOrWarn(String trimmedLine) {
+        assert trimmedLine != null : "trimmedLine should not be null";
+        assert !trimmedLine.isBlank() : "decodeOrWarn expects non-blank line";
+
+        try {
+            Task t = formatter.decode(trimmedLine);
+            assert t != null : "formatter.decode() returned null for line: " + trimmedLine;
+            return Optional.of(t);
+        } catch (Exception corruptedLine) {
+            System.out.println(separator);
+            System.out.println("! Warning: " + corruptedLine.getMessage());
+            System.out.println(separator);
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
Storage reads tasks by iterating over file lines and manually building collections.

The loop-based approach works but obscures the intent of the code and scatters filtering and transformation logic across multiple steps.

Let's refactor Storage to use Java Streams where it fits naturally: transform file lines to tasks using a stream pipeline, and transform tasks to encoded lines in save() via mapping and collecting.

Using Streams makes the data flow clearer and reduces boilerplate while preserving existing behavior such as skipping empty lines and warning on corrupted entries.